### PR TITLE
Add example React hooks to snippet library

### DIFF
--- a/packages/react-hooks/src/useDebounce.js
+++ b/packages/react-hooks/src/useDebounce.js
@@ -1,0 +1,12 @@
+// useDebounce.js
+// Debounces a value by a given delay
+import { useState, useEffect } from 'react';
+
+export function useDebounce(value, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debounced;
+}

--- a/packages/react-hooks/src/useInterval.js
+++ b/packages/react-hooks/src/useInterval.js
@@ -1,0 +1,17 @@
+// useInterval.js
+// Runs a callback at a specified interval
+import { useEffect, useRef } from 'react';
+
+export function useInterval(callback, delay) {
+  const savedCallback = useRef();
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (delay === null) return;
+    const id = setInterval(() => savedCallback.current(), delay);
+    return () => clearInterval(id);
+  }, [delay]);
+}

--- a/packages/react-hooks/src/useOnClickOutside.js
+++ b/packages/react-hooks/src/useOnClickOutside.js
@@ -1,0 +1,20 @@
+// useOnClickOutside.js
+// Calls handler when a click occurs outside the referenced element
+import { useEffect } from 'react';
+
+export function useOnClickOutside(ref, handler) {
+  useEffect(() => {
+    function listener(event) {
+      if (!ref.current || ref.current.contains(event.target)) {
+        return;
+      }
+      handler(event);
+    }
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+}

--- a/packages/react-hooks/src/usePrevious.js
+++ b/packages/react-hooks/src/usePrevious.js
@@ -1,0 +1,11 @@
+// usePrevious.js
+// Returns the previous value of a prop or state
+import { useRef, useEffect } from 'react';
+
+export function usePrevious(value) {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}

--- a/packages/react-hooks/src/useToggle.js
+++ b/packages/react-hooks/src/useToggle.js
@@ -1,0 +1,9 @@
+// useToggle.js
+// A simple reusable React hook for toggling boolean state
+import { useState, useCallback } from 'react';
+
+export function useToggle(initial = false) {
+  const [value, setValue] = useState(initial);
+  const toggle = useCallback(() => setValue(v => !v), []);
+  return [value, toggle];
+}


### PR DESCRIPTION
This PR adds several reusable React hook examples to the new monorepo structure:
- useToggle
- usePrevious
- useDebounce
- useInterval
- useOnClickOutside

These hooks are framework-agnostic and ready for use and testing.